### PR TITLE
remove execsync and add sync-exec to work with node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,21 +28,22 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
     "grunt": "~0.4.0",
-    "execSync": "0.0.3"
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt-contrib-jshint": "~0.1.1",
+    "grunt-contrib-nodeunit": "^0.4.1",
+    "sync-exec": "^0.5.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"
   },
   "keywords": [
     "gruntplugin",
-	"preloadjs",
-	"preload",
-	"manifest",
-	"pxloader",
-	"generator"
-  ]
+    "preloadjs",
+    "preload",
+    "manifest",
+    "pxloader",
+    "generator"
+  ],
+  "dependencies": {}
 }

--- a/tasks/preload_assets.js
+++ b/tasks/preload_assets.js
@@ -20,7 +20,7 @@ module.exports = function (grunt) {
 	var execSync;
 
 	if (imagesEngine === 'sips') {
-		execSync = require('execSync');
+		execSync = require('sync-exec');
 	}
 
 


### PR DESCRIPTION
hey @gunta.  I like using this package and I've upgraded to node 0.12.  It seems you can use sync-exec instead of execSync to be compatible with +0.12 as well as with earlier versions of node.  This change passed the working tests in the example repo.

Let me know if there is something else you have a question on.  Otherwise I would love to get this up on npm so that I can use it straight from there.

Thanks
